### PR TITLE
Chroma: readme: some additional guidance for common install issues

### DIFF
--- a/Chromatography/README-GC.md
+++ b/Chromatography/README-GC.md
@@ -2,9 +2,25 @@
 
 ## i) Setup (Start Here!!!)
 
-The chromatography file parser is a command line tool that invokes a python script. This means you can run the script from your Terminal (mac), or terminal-emulator in Windows (Putty, powershell, etc.). In order to run this, you must have **python3** installed
-Once python3 is install, you will need to install the package _scipy_ from python. To do this, simply navigate to your terminal and install it via pip:  
-`$ pip install scipy`
+The chromatography file parser is a command line tool that invokes a python script. This means you can run the script from your Terminal (mac), or terminal-emulator in Windows (Putty, powershell, etc.), which we will refer to as "your terminal." In order to run this, you must have [**python3**](https://www.python.org/downloads/) installed .
+
+
+With your terminal opened, check to make sure you have python3 installed by running these commands:
+```
+python --version
+```
+or
+```
+python3 --version
+```
+
+One of those commands should show "Python 3.9" or newer if you have python3 installed correctly. For the remaining steps, use the command (`python` or `python3`) that worked.
+
+You will now need to install a python package called _scipy_. To do this, simply navigate to your terminal and install it via pip:  
+
+```
+python -m pip install --user scipy
+```
 
 ## ii) Run the command (CLI - most people do this)
 


### PR DESCRIPTION
Couple updates to avoid common problems I've seen in the past. Though I may have made the language a bit hard to understand, so I welcome any edits.

1. Run pip from python to ensure the correct path is used. Without virtual environment instructions, it is common people may have multiple python versions and multiple pip versions, so when they run `pip install` it doesn't "go" to the python version they expect
2. Doing a `--user` install causes less issues on macOS and Linux with requiring sudo, or just discovering where the packages are installed on the filesystem. Not sure about Windows.